### PR TITLE
Makefile: fix linking of ncurses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,22 +10,22 @@
 PREFIX = /usr/local
 
 tomato: tomato.o util.o input.o update.o anim.o
-	gcc -lncurses -o tomato tomato.o util.o input.o update.o anim.o
+	gcc -o tomato tomato.o util.o input.o update.o anim.o -lncurses
 
 tomato.o: tomato.c util.h input.h update.h anim.h
-	gcc -lncurses -c -g tomato.c
+	gcc -c -g tomato.c -lncurses
 
 util.o: util.c util.h
-	gcc -lncurses -c -g util.c
+	gcc -c -g util.c -lncurses
 
 anim.o: anim.c anim.h
-	gcc -lncurses -c -g anim.c
+	gcc -c -g anim.c -lncurses
 
 input.o: input.c input.h
-	gcc -lncurses -c -g input.c
+	gcc -c -g input.c -lncurses
 
 update.o: update.c update.h
-	gcc -lncurses -c -g update.c
+	gcc -c -g update.c -lncurses
 
 clean:
 	rm -rf tomato tomato.o util.o input.o update.o anim.o


### PR DESCRIPTION
Unable to link ncurses:

Logs:
    /usr/bin/ld: tomato.o: in function `drawScreen':
    /home/mgemzon/Personal/cool/Tomato.C/tomato.c:42: undefined reference to `stdscr'
    /usr/bin/ld: /home/mgemzon/Personal/cool/Tomato.C/tomato.c:42: undefined reference to `werase'
    /usr/bin/ld: /home/mgemzon/Personal/cool/Tomato.C/tomato.c:73: undefined reference to `stdscr'
    /usr/bin/ld: /home/mgemzon/Personal/cool/Tomato.C/tomato.c:73: undefined reference to `wrefresh'
    /usr/bin/ld: tomato.o: in function `main':
    /home/mgemzon/Personal/cool/Tomato.C/tomato.c:96: undefined reference to `napms'
    /usr/bin/ld: util.o: in function `initScreen':
    /home/mgemzon/Personal/cool/Tomato.C/util.c:26: undefined reference to `initscr'
    /usr/bin/ld: /home/mgemzon/Personal/cool/Tomato.C/util.c:28: undefined reference to `use_default_colors'
    /usr/bin/ld: /home/mgemzon/Personal/cool/Tomato.C/util.c:29: undefined reference to `has_colors'
    /usr/bin/ld: /home/mgemzon/Personal/cool/Tomato.C/util.c:31: undefined reference to `start_color'
    /usr/bin/ld: /home/mgemzon/Personal/cool/Tomato.C/util.c:34: undefined reference to `init_pair'
    /usr/bin/ld: /home/mgemzon/Personal/cool/Tomato.C/util.c:37: undefined reference to `noecho'
    /usr/bin/ld: /home/mgemzon/Personal/cool/Tomato.C/util.c:39: undefined reference to `cbreak'
    /usr/bin/ld: /home/mgemzon/Personal/cool/Tomato.C/util.c:41: undefined reference to `curs_set'
    /usr/bin/ld: /home/mgemzon/Personal/cool/Tomato.C/util.c:43: undefined reference to `stdscr'
    /usr/bin/ld: /home/mgemzon/Personal/cool/Tomato.C/util.c:43: undefined reference to `nodelay'
    /usr/bin/ld: /home/mgemzon/Personal/cool/Tomato.C/util.c:45: undefined reference to `stdscr'
    /usr/bin/ld: /home/mgemzon/Personal/cool/Tomato.C/util.c:45: undefined reference to `keypad'
    /usr/bin/ld: util.o: in function `setColor':
    /home/mgemzon/Personal/cool/Tomato.C/util.c:52: undefined reference to `stdscr'
    /usr/bin/ld: /home/mgemzon/Personal/cool/Tomato.C/util.c:52: undefined reference to `wattrset'
    /usr/bin/ld: util.o: in function `getWindowSize':
    /home/mgemzon/Personal/cool/Tomato.C/util.c:57: undefined reference to `stdscr'
    /usr/bin/ld: /home/mgemzon/Personal/cool/Tomato.C/util.c:57: undefined reference to `stdscr'
    /usr/bin/ld: /home/mgemzon/Personal/cool/Tomato.C/util.c:57: undefined reference to `stdscr'
    /usr/bin/ld: /home/mgemzon/Personal/cool/Tomato.C/util.c:57: undefined reference to `stdscr'
    /usr/bin/ld: util.o: in function `printPomodoroCounter':
    /home/mgemzon/Personal/cool/Tomato.C/util.c:78: undefined reference to `mvprintw'
    /usr/bin/ld: /home/mgemzon/Personal/cool/Tomato.C/util.c:82: undefined reference to `mvprintw'
    /usr/bin/ld: util.o: in function `printMainMenu':
    /home/mgemzon/Personal/cool/Tomato.C/util.c:92: undefined reference to `mvprintw'
    /usr/bin/ld: /home/mgemzon/Personal/cool/Tomato.C/util.c:95: undefined reference to `mvprintw'
    /usr/bin/ld: /home/mgemzon/Personal/cool/Tomato.C/util.c:100: undefined reference to `mvprintw'
    /usr/bin/ld: util.o:/home/mgemzon/Personal/cool/Tomato.C/util.c:103: more undefined references to `mvprintw' follow
    /usr/bin/ld: input.o: in function `handleInputs':
    /home/mgemzon/Personal/cool/Tomato.C/input.c:23: undefined reference to `stdscr'
    /usr/bin/ld: /home/mgemzon/Personal/cool/Tomato.C/input.c:23: undefined reference to `wgetch'
    /usr/bin/ld: /home/mgemzon/Personal/cool/Tomato.C/input.c:83: undefined reference to `endwin'
    /usr/bin/ld: /home/mgemzon/Personal/cool/Tomato.C/input.c:88: undefined reference to `endwin'
    /usr/bin/ld: /home/mgemzon/Personal/cool/Tomato.C/input.c:91: undefined reference to `stdscr'
    /usr/bin/ld: /home/mgemzon/Personal/cool/Tomato.C/input.c:91: undefined reference to `werase'
    /usr/bin/ld: /home/mgemzon/Personal/cool/Tomato.C/input.c:92: undefined reference to `stdscr'
    /usr/bin/ld: /home/mgemzon/Personal/cool/Tomato.C/input.c:92: undefined reference to `wrefresh'
    /usr/bin/ld: input.o: in function `mainMenuInput':
    /home/mgemzon/Personal/cool/Tomato.C/input.c:112: undefined reference to `endwin'
    /usr/bin/ld: /home/mgemzon/Personal/cool/Tomato.C/input.c:133: undefined reference to `endwin'
    /usr/bin/ld: anim.o: in function `printLogo':
    /home/mgemzon/Personal/cool/Tomato.C/anim.c:36: undefined reference to `mvprintw'
    /usr/bin/ld: /home/mgemzon/Personal/cool/Tomato.C/anim.c:37: undefined reference to `mvprintw'
    /usr/bin/ld: /home/mgemzon/Personal/cool/Tomato.C/anim.c:39: undefined reference to `mvprintw'
    /usr/bin/ld: /home/mgemzon/Personal/cool/Tomato.C/anim.c:40: undefined reference to `mvprintw'
    /usr/bin/ld: /home/mgemzon/Personal/cool/Tomato.C/anim.c:41: undefined reference to `mvprintw'
    /usr/bin/ld: anim.o:/home/mgemzon/Personal/cool/Tomato.C/anim.c:42: more undefined references to `mvprintw' follow
    collect2: error: ld returned 1 exit status
    make: *** [Makefile:13: tomato] Error 1