### PR TITLE
❄️  Fetching source from remote repository + pkgs import via ternary operator

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,14 +6,17 @@
 #  ,|
 #  `'
 # default.nix
-{}: let
-  pkgs = import <nixpkgs> {};
-  lib = pkgs.lib;
+{pkgs ? import <nixpkgs> {}}: let
+  repository-url = "https://github.com/gabrielzschmitz/Tomato.C";
 in
   pkgs.stdenv.mkDerivation {
     name = "tomato";
 
-    src = ./.;
+    src = pkgs.fetchgit {
+      url = repository-url;
+      rev = "dda8e0ffe0b8612691ed336962f33580fb3a6038";
+      sha256 = "193xr63s4700bsamac0zjff0l6n8bcm60f546jfxqaafz126f9zv";
+    };
 
     installPhase = ''
       mkdir -p $out/bin && cp tomato $out/bin/
@@ -35,9 +38,9 @@ in
       mpv
     ];
 
-    meta = with lib; {
+    meta = with pkgs.lib; {
       description = "A pomodoro timer written in pure C.";
-      homepage = "https://github.com/gabrielzschmitz/Tomato.C";
+      homepage = repository-url;
       license = licenses.gpl3Plus;
       maintainers = with maintainers; [luisnquin];
     };


### PR DESCRIPTION
Personally, I don't think that `src = ./.` gets too useful for now, this new .nix file version installs tomato from GitHub

You only will need to update the `sha256` and `rev` with the data from the generated JSON in `nix-prefetch-git <repo-url>` for each big change that you do in the program

Example:
```
$ nix-prefetch-git https://github.com/gabrielzschmitz/Tomato.C
git revision is dda8e0ffe0b8612691ed336962f33580fb3a6038
path is /nix/store/q251xbkaixg6h5d8r405ngpr6lx6hqxk-Tomato.C
git human-readable version is -- none --
Commit date is 2023-01-25 20:49:09 -0300
hash is 193xr63s4700bsamac0zjff0l6n8bcm60f546jfxqaafz126f9zv
{
  "url": "https://github.com/gabrielzschmitz/Tomato.C",
  "rev": "dda8e0ffe0b8612691ed336962f33580fb3a6038",
  "date": "2023-01-25T20:49:09-03:00",
  "path": "/nix/store/q251xbkaixg6h5d8r405ngpr6lx6hqxk-Tomato.C",
  "sha256": "193xr63s4700bsamac0zjff0l6n8bcm60f546jfxqaafz126f9zv",
  "fetchLFS": false,
  "fetchSubmodules": false,
  "deepClone": false,
  "leaveDotGit": false
}
```

Now there are two ways of installation

- By cloning the repository and using Nix package manager and executing `$ nix-build default.nix`

- Or if using `NixOS` by adding the .nix file to the `configuration.nix` and then calling it like [here](https://github.com/luisnquin/nixos-config/blob/main/pkgs/default.nix)

I guess that's it, maybe later if I find it useful I'll add a `flake.nix`, but for now this is enough