### PR TITLE
❄️  Using builtins.path instead of a raw path

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -20,7 +20,10 @@
 stdenv.mkDerivation {
   name = "tomato";
 
-  src = ./.;
+  src = builtins.path {
+    name = "Tomato.C";
+    path = ./.;
+  };
 
   installPhase = ''
     mkdir -p $out/bin && cp tomato tomatonoise $out/bin/


### PR DESCRIPTION
As the title suggest


Here's the reason for my change
https://nix.dev/recipes/best-practices#reproducible-source-paths