### PR TITLE
Build test for Ubuntu and macOS operative systems

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,20 @@
+name: Build test
+on:
+  - push
+  - pull_request
+jobs:
+  ubuntu-build-test:
+    name: Build project (Ubuntu)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install build dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y build-essential pkg-config \
+            libncurses5-dev libncursesw5-dev libmpv-dev mpv libnotify4
+      - name: Compiles project
+        run: |
+          sudo make install
+        run: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -28,7 +28,9 @@ jobs:
         uses: melusina-org/setup-macports@v1.1.2
       - name: Install build dependencies
         run: |
-          brew install gcc && sudo port install ncurses mpv
+          brew install gcc
+          sudo port install ncurses
+          sudo port install mpv-legacy +libmpv
       - name: Compile project
         run: |
           sudo make install

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -14,7 +14,21 @@ jobs:
           sudo apt update
           sudo apt install -y build-essential pkg-config \
             libncurses5-dev libncursesw5-dev libmpv-dev mpv libnotify4
-      - name: Compiles project
+      - name: Compile project
         run: |
           sudo make install
+
+  macos-build-test:
+    name: Build project (macOS)
+    runs-on: macos-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup MacPorts
+        uses: melusina-org/setup-macports@v1.1.2
+      - name: Install build dependencies
         run: |
+          brew install gcc && sudo port install ncurses mpv
+      - name: Compile project
+        run: |
+          sudo make install

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -18,19 +18,19 @@ jobs:
         run: |
           sudo make install
 
-  macos-build-test:
-    name: Build project (macOS)
-    runs-on: macos-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Setup MacPorts
-        uses: melusina-org/setup-macports@v1.1.2
-      - name: Install build dependencies
-        run: |
-          brew install gcc
-          sudo port install ncurses
-          sudo port install mpv-legacy +libmpv
-      - name: Compile project
-        run: |
-          sudo make install
+  # macos-build-test:
+  #   name: Build project (macOS)
+  #   runs-on: macos-latest
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v4
+  #     - name: Setup MacPorts
+  #       uses: melusina-org/setup-macports@v1.1.2
+  #     - name: Install build dependencies
+  #       run: |
+  #         brew install gcc
+  #         sudo port install ncurses
+  #         sudo port install mpv-legacy +libmpv
+  #     - name: Compile project
+  #       run: |
+  #         sudo make install


### PR DESCRIPTION
For reliability reasons I'd like to add these CI actions.

Take into account that the build process for macOS can take at least 5 minutes to be completed.