### PR TITLE
🖍 Fixing black in black prints at coffe smoke and gears

### DIFF
--- a/anim.c
+++ b/anim.c
@@ -209,7 +209,7 @@ void printCoffee(appData* app) {
   int startx = app->middlex - 3;
   int starty = app->middley - 2;
   int frameIndex = app->coffeeFrame * 6;
-  int lineColor[6] = {COLOR_BLACK, COLOR_BLACK, COLOR_WHITE,
+  int lineColor[6] = {COLOR_WHITE, COLOR_WHITE, COLOR_WHITE,
                       COLOR_WHITE, COLOR_WHITE, COLOR_WHITE};
 
   for (int i = 0; i < 6; i++) {
@@ -358,7 +358,7 @@ void printWrench(appData* app, int flip) {
     starty = app->middley - 9;
   }
 
-  setColor(COLOR_BLACK, COLOR_BLACK, A_BOLD);
+  setColor(COLOR_WHITE, COLOR_BLACK, A_BOLD);
   for (int i = 0; i < 5; i++) {
     mvprintw(starty + i, startx, "%s", wrenchFrames[i]);
   }


### PR DESCRIPTION
I was not possible to see both the coffee smoke and the cute wrenches at the configuration screen. So I fixed some "Black in Black" prints that I found at `anim.c`

## Before
![Skip_bug_click](https://github.com/gabrielzschmitz/Tomato.C/assets/85318248/3967e747-908e-48ab-a32e-ae2521afbcf7)
This is a giff from a bug I already reported at issue #40 . But the important part is the absence of the smoke.

![Screenshot-2024-03-23_23-18-54](https://github.com/gabrielzschmitz/Tomato.C/assets/85318248/fedad894-54ad-448a-86ec-c62684f10113)

## After
![Screenshot-2024-03-23_23-20-13](https://github.com/gabrielzschmitz/Tomato.C/assets/85318248/ac96c57e-564b-4447-a78e-e755de7ae55e)
![Screenshot-2024-03-23_23-29-58](https://github.com/gabrielzschmitz/Tomato.C/assets/85318248/c9330b72-2d29-42b1-bfc2-75c96343cc15)

