### PR TITLE
🔧 Initializes unitialized machineFrame animation variable

### DIFF
--- a/tomato.c
+++ b/tomato.c
@@ -35,6 +35,7 @@ void initApp(appData *app) {
   /* Animation variables */
   app->logoFrame = 0;
   app->coffeeFrame = 0;
+  app->machineFrame = 0;
   app->bannerFrame = 0;
   app->helpFrame = 0;
   app->notepadFrame = 0;


### PR DESCRIPTION
## The Problem
As reported in the issue #40, sometimes the action of skipping the Pomodoro was causing weird segmentation faults.

After some debugging I discovered that the frameIndex was behaving weirdly at:
```c
/* Print the coffee machine frames */
void printMachine(appData* app) {
// ...
int frameIndex = app->machineFrame * 11;
// ...
for (int i = 0; i < 11; i++) {
    mvprintw(starty + i, startx, "%s", machineFrames[frameIndex + i]);
  }
// ...
```
Causing unexpected illegal memory accesses at `machineFrames`. I printed the value of frameIndex in the giff available at *Before* section.

## The Solution
Apparently the problem was solved by initializing the `app->machineFrame` with the other *Animation Variables* at `tomato.c`

```c
//...
  /* Animation variables */
  app->logoFrame = 0;
  app->coffeeFrame = 0;
  app->machineFrame = 0;
  app->bannerFrame = 0;
  app->helpFrame = 0;
  app->notepadFrame = 0;
  app->frameTimer = 0;
  app->framems = 0;
//...
```

## Before:
![FrameIndex_bug_cropped](https://github.com/gabrielzschmitz/Tomato.C/assets/85318248/42146445-c9f1-4417-aee5-5a0e69597109)

## After:
![WorkingWithoutProblem_cropped](https://github.com/gabrielzschmitz/Tomato.C/assets/85318248/dcc88d7c-8fbb-4b85-a8c3-83fe94cde811)