### PR TITLE
🔧 Fixes memmory leak - definitely lost blocks

### DIFF
--- a/input.c
+++ b/input.c
@@ -374,6 +374,8 @@ void handleInputs(appData *app) {
           if (WORKLOG == 1) writeToLog(app);
           if (TIMERLOG == 1) endTimerLog(app);
           endwin();
+          deallocateNotepad(app);
+          deallocateFileNames(app);
           printf("Goodbye!\n");
           exit(EXIT_SUCCESS);
         } else if (app->currentMode == -3) {
@@ -905,6 +907,8 @@ void mainMenuInput(appData *app, char key) {
       killNoise();
       if (TIMERLOG == 1) endTimerLog(app);
       endwin();
+      deallocateNotepad(app);
+      deallocateFileNames(app);
       printf("Goodbye!\n");
       exit(EXIT_SUCCESS);
     }
@@ -941,6 +945,8 @@ void mainMenuInput(appData *app, char key) {
       killNoise();
       if (TIMERLOG == 1) endTimerLog(app);
       endwin();
+      deallocateNotepad(app);
+      deallocateFileNames(app);
       printf("Goodbye!\n");
       exit(EXIT_SUCCESS);
     }

--- a/tomato.c
+++ b/tomato.c
@@ -90,7 +90,6 @@ void initApp(appData *app) {
   app->runNotepadOnce = 1;
 
   /* Notepad variables */
-  createNotepad(&app->notes);
   app->emptyNotepad = 1;
   app->inputLength = 0;
   app->notesAmount = 0;
@@ -230,6 +229,7 @@ int main(int argc, char *argv[]) {
     char *timerFile = malloc(strlen(TIMERFILE) + 1);
     strcpy(timerFile, TIMERFILE);
     int status = tomatoTimer(timerFile);
+    free(timerFile);
     return status;
   } else if (argc == 2 && !strcmp("-t", argv[1]) && TIMERLOG != 1) {
     printf("enable timer log to use [-t]");

--- a/util.c
+++ b/util.c
@@ -32,10 +32,27 @@ note *createNote(char type) {
   return newNote;
 }
 
-/* Function to create a new notepad */
-notepad *createNotepad(notepad *notes) {
-  notes = (notepad *)malloc(sizeof(notepad));
-  return notes;
+/* Function to free allocated memory for notepad */
+void deallocateNotepad(appData *app) {
+    for(int i = 0; i < app->notesAmount; i++) {
+        free(app->notes.lines[i]->note);
+        free(app->notes.lines[i]);
+    }
+}
+
+/* Function to free allocated memory for file names */
+void deallocateFileNames(appData *app) {
+  free(app->logPrefix);
+  if (WORKLOG == 1) {
+   free(app->logFile);
+   free(app->tmpFile);
+  }
+  if (TIMERLOG == 1) {
+    free(app->timerFile);
+  }
+  if (NOTEPADLOG == 1) {
+    free(app->notepadFile);
+  }
 }
 
 /* Initialize screen with colors, enabled keyboard and another little configs */
@@ -101,6 +118,7 @@ void createLog(appData *app) {
   strcpy(logPrefix, home);
   strcat(logPrefix, "/");
   strcat(logPrefix, app->logPrefix);
+  free(app->logPrefix); // Deallocates memmory allocated at appInit() -- tomato.c
   app->logPrefix = logPrefix;
 
   /* Set log file fullpath */
@@ -109,6 +127,7 @@ void createLog(appData *app) {
   strcpy(logFile, home);
   strcat(logFile, "/");
   strcat(logFile, app->logFile);
+  free(app->logFile); // Deallocates memmory allocated at appInit() -- tomato.c
   app->logFile = logFile;
 
   /* Set tmp file fullpath */
@@ -117,6 +136,7 @@ void createLog(appData *app) {
   strcpy(tmpFile, home);
   strcat(tmpFile, "/");
   strcat(tmpFile, app->tmpFile);
+  free(app->tmpFile); // Deallocates memmory allocated at appInit() -- tomato.c
   app->tmpFile = tmpFile;
 
   /* Set timer file fullpath */
@@ -125,6 +145,7 @@ void createLog(appData *app) {
   strcpy(timerFile, home);
   strcat(timerFile, "/");
   strcat(timerFile, app->timerFile);
+  free(app->timerFile); // Deallocates memmory allocated at appInit() -- tomato.c
   app->timerFile = timerFile;
 
   /* Set notepad file fullpath */
@@ -133,6 +154,7 @@ void createLog(appData *app) {
   strcpy(notepadFile, home);
   strcat(notepadFile, "/");
   strcat(notepadFile, app->notepadFile);
+  free(app->notepadFile); // Deallocates memmory allocated at appInit() -- tomato.c
   app->notepadFile = notepadFile;
 
   /* Create log folder */
@@ -318,6 +340,7 @@ void readNotepad(appData *app) {
     else if (sscanf(line, " -  %[^\n]", note))
       app->notes.lines[app->notesAmount]->type = '-';
     strcpy(app->notes.lines[app->notesAmount]->note, note);
+    free(note);
     app->notesAmount += 1;
     app->emptyNotepad = 0;
   }
@@ -479,6 +502,9 @@ int tomatoTimer(const char *timerFile) {
 
   /* Print the timer file content */
   int status = printTimerLog(path);
+
+  /* Free Path */
+  free(path);
 
   /* Return exit status */
   return status;

--- a/util.h
+++ b/util.h
@@ -19,8 +19,10 @@
 
 /* Function to create a new note */
 extern note* createNote(char);
-/* Function to create a new notepad */
-extern notepad* createNotepad(notepad*);
+/* Function to free allocated memory for notepad */
+extern void deallocateNotepad(appData *app);
+/* Function to free allocated memory for file names */
+extern void deallocateFileNames(appData *app);
 
 /* Initialize screen with some little configs */
 extern void initScreen(void);


### PR DESCRIPTION
## The Problem:
Yesterday, while I was searching for the bug I reported at #44, I came across many `mallocs` throughout the code. But, when out of curiosity I looked for where these were free, I simply didn't find any `free()` calls in the code.

So, I ran `valgrind` to see what was going on (logs available below). Apparently there was 2 types of "problems", some group of blocks were apparently lost due to `initscr` and the other group were obviously the allocated blocks not released.

After a quick googling I was convinced that the `initscr` blocks were not in fact lost, but that `valgrind` was not seeing the dynamic library deallocate them. So I focused on the **definitively lost blocks** that were actually resulting in *memory leaks*. I was time for some plumbing!

The after/before logs of `valgrind` can be viewed bellow.

## Before:

### Full Log:
```bash
valgrind --track-origins=yes --leak-check=full ./result/bin/tomato  
==30886== Memcheck, a memory error detector
==30886== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==30886== Using Valgrind-3.22.0 and LibVEX; rerun with -h for copyright info
==30886== Command: ./result/bin/tomato
==30886== 
Goodbye!
==30886== 
==30886== HEAP SUMMARY:
==30886==     in use at exit: 469,624 bytes in 480 blocks
==30886==   total heap usage: 5,412 allocs, 4,932 frees, 3,429,927 bytes allocated
==30886== 
==30886== 9 bytes in 1 blocks are possibly lost in loss record 7 of 119
==30886==    at 0x484276B: malloc (in /nix/store/drfy02sf3aqzk6cdrs4lyxa8a6jprl5q-valgrind-3.22.0/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==30886==    by 0x4C77B0D: strdup (in /nix/store/ibp4camsx1mlllwzh32yyqcq2r2xsy1a-glibc-2.37-8/lib/libc.so.6)
==30886==    by 0x489A825: tparm_setup (in /nix/store/1ql93amj3rmq5yg7qry7ky6gwpbvdgxp-ncurses-6.4/lib/libncursesw.so.6.4)
==30886==    by 0x489DB10: _nc_tiparm (in /nix/store/1ql93amj3rmq5yg7qry7ky6gwpbvdgxp-ncurses-6.4/lib/libncursesw.so.6.4)
==30886==    by 0x487B8DD: _nc_mvcur_init_sp (in /nix/store/1ql93amj3rmq5yg7qry7ky6gwpbvdgxp-ncurses-6.4/lib/libncursesw.so.6.4)
==30886==    by 0x487C258: newterm_sp (in /nix/store/1ql93amj3rmq5yg7qry7ky6gwpbvdgxp-ncurses-6.4/lib/libncursesw.so.6.4)
==30886==    by 0x487C527: newterm (in /nix/store/1ql93amj3rmq5yg7qry7ky6gwpbvdgxp-ncurses-6.4/lib/libncursesw.so.6.4)
==30886==    by 0x487835F: initscr (in /nix/store/1ql93amj3rmq5yg7qry7ky6gwpbvdgxp-ncurses-6.4/lib/libncursesw.so.6.4)
==30886==    by 0x408F06: initScreen (in /nix/store/aakvc5vgnbibxp8rl9b165vmmpxd5ikl-tomato/bin/tomato)
==30886==    by 0x402467: main (in /nix/store/aakvc5vgnbibxp8rl9b165vmmpxd5ikl-tomato/bin/tomato)
==30886== 
==30886== 9 bytes in 1 blocks are possibly lost in loss record 8 of 119
==30886==    at 0x484276B: malloc (in /nix/store/drfy02sf3aqzk6cdrs4lyxa8a6jprl5q-valgrind-3.22.0/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==30886==    by 0x4C77B0D: strdup (in /nix/store/ibp4camsx1mlllwzh32yyqcq2r2xsy1a-glibc-2.37-8/lib/libc.so.6)
==30886==    by 0x489A825: tparm_setup (in /nix/store/1ql93amj3rmq5yg7qry7ky6gwpbvdgxp-ncurses-6.4/lib/libncursesw.so.6.4)
==30886==    by 0x489DB10: _nc_tiparm (in /nix/store/1ql93amj3rmq5yg7qry7ky6gwpbvdgxp-ncurses-6.4/lib/libncursesw.so.6.4)
==30886==    by 0x487BB86: _nc_mvcur_init_sp (in /nix/store/1ql93amj3rmq5yg7qry7ky6gwpbvdgxp-ncurses-6.4/lib/libncursesw.so.6.4)
==30886==    by 0x487C258: newterm_sp (in /nix/store/1ql93amj3rmq5yg7qry7ky6gwpbvdgxp-ncurses-6.4/lib/libncursesw.so.6.4)
==30886==    by 0x487C527: newterm (in /nix/store/1ql93amj3rmq5yg7qry7ky6gwpbvdgxp-ncurses-6.4/lib/libncursesw.so.6.4)
==30886==    by 0x487835F: initscr (in /nix/store/1ql93amj3rmq5yg7qry7ky6gwpbvdgxp-ncurses-6.4/lib/libncursesw.so.6.4)
==30886==    by 0x408F06: initScreen (in /nix/store/aakvc5vgnbibxp8rl9b165vmmpxd5ikl-tomato/bin/tomato)
==30886==    by 0x402467: main (in /nix/store/aakvc5vgnbibxp8rl9b165vmmpxd5ikl-tomato/bin/tomato)
==30886== 
==30886== 20 bytes in 1 blocks are definitely lost in loss record 16 of 119
==30886==    at 0x484276B: malloc (in /nix/store/drfy02sf3aqzk6cdrs4lyxa8a6jprl5q-valgrind-3.22.0/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==30886==    by 0x40278B: initApp (in /nix/store/aakvc5vgnbibxp8rl9b165vmmpxd5ikl-tomato/bin/tomato)
==30886==    by 0x40246F: main (in /nix/store/aakvc5vgnbibxp8rl9b165vmmpxd5ikl-tomato/bin/tomato)
==30886== 
==30886== 24 bytes in 1 blocks are possibly lost in loss record 31 of 119
==30886==    at 0x484276B: malloc (in /nix/store/drfy02sf3aqzk6cdrs4lyxa8a6jprl5q-valgrind-3.22.0/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==30886==    by 0x4CDD3A5: tsearch (in /nix/store/ibp4camsx1mlllwzh32yyqcq2r2xsy1a-glibc-2.37-8/lib/libc.so.6)
==30886==    by 0x489A840: tparm_setup (in /nix/store/1ql93amj3rmq5yg7qry7ky6gwpbvdgxp-ncurses-6.4/lib/libncursesw.so.6.4)
==30886==    by 0x489DB10: _nc_tiparm (in /nix/store/1ql93amj3rmq5yg7qry7ky6gwpbvdgxp-ncurses-6.4/lib/libncursesw.so.6.4)
==30886==    by 0x487B8DD: _nc_mvcur_init_sp (in /nix/store/1ql93amj3rmq5yg7qry7ky6gwpbvdgxp-ncurses-6.4/lib/libncursesw.so.6.4)
==30886==    by 0x487C258: newterm_sp (in /nix/store/1ql93amj3rmq5yg7qry7ky6gwpbvdgxp-ncurses-6.4/lib/libncursesw.so.6.4)
==30886==    by 0x487C527: newterm (in /nix/store/1ql93amj3rmq5yg7qry7ky6gwpbvdgxp-ncurses-6.4/lib/libncursesw.so.6.4)
==30886==    by 0x487835F: initscr (in /nix/store/1ql93amj3rmq5yg7qry7ky6gwpbvdgxp-ncurses-6.4/lib/libncursesw.so.6.4)
==30886==    by 0x408F06: initScreen (in /nix/store/aakvc5vgnbibxp8rl9b165vmmpxd5ikl-tomato/bin/tomato)
==30886==    by 0x402467: main (in /nix/store/aakvc5vgnbibxp8rl9b165vmmpxd5ikl-tomato/bin/tomato)
==30886== 
==30886== 24 bytes in 1 blocks are possibly lost in loss record 32 of 119
==30886==    at 0x484276B: malloc (in /nix/store/drfy02sf3aqzk6cdrs4lyxa8a6jprl5q-valgrind-3.22.0/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==30886==    by 0x4CDD3A5: tsearch (in /nix/store/ibp4camsx1mlllwzh32yyqcq2r2xsy1a-glibc-2.37-8/lib/libc.so.6)
==30886==    by 0x489A840: tparm_setup (in /nix/store/1ql93amj3rmq5yg7qry7ky6gwpbvdgxp-ncurses-6.4/lib/libncursesw.so.6.4)
==30886==    by 0x489DB10: _nc_tiparm (in /nix/store/1ql93amj3rmq5yg7qry7ky6gwpbvdgxp-ncurses-6.4/lib/libncursesw.so.6.4)
==30886==    by 0x487BB86: _nc_mvcur_init_sp (in /nix/store/1ql93amj3rmq5yg7qry7ky6gwpbvdgxp-ncurses-6.4/lib/libncursesw.so.6.4)
==30886==    by 0x487C258: newterm_sp (in /nix/store/1ql93amj3rmq5yg7qry7ky6gwpbvdgxp-ncurses-6.4/lib/libncursesw.so.6.4)
==30886==    by 0x487C527: newterm (in /nix/store/1ql93amj3rmq5yg7qry7ky6gwpbvdgxp-ncurses-6.4/lib/libncursesw.so.6.4)
==30886==    by 0x487835F: initscr (in /nix/store/1ql93amj3rmq5yg7qry7ky6gwpbvdgxp-ncurses-6.4/lib/libncursesw.so.6.4)
==30886==    by 0x408F06: initScreen (in /nix/store/aakvc5vgnbibxp8rl9b165vmmpxd5ikl-tomato/bin/tomato)
==30886==    by 0x402467: main (in /nix/store/aakvc5vgnbibxp8rl9b165vmmpxd5ikl-tomato/bin/tomato)
==30886== 
==30886== 28 bytes in 1 blocks are definitely lost in loss record 36 of 119
==30886==    at 0x484276B: malloc (in /nix/store/drfy02sf3aqzk6cdrs4lyxa8a6jprl5q-valgrind-3.22.0/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==30886==    by 0x4027D3: initApp (in /nix/store/aakvc5vgnbibxp8rl9b165vmmpxd5ikl-tomato/bin/tomato)
==30886==    by 0x40246F: main (in /nix/store/aakvc5vgnbibxp8rl9b165vmmpxd5ikl-tomato/bin/tomato)
==30886== 
==30886== 29 bytes in 1 blocks are definitely lost in loss record 37 of 119
==30886==    at 0x484276B: malloc (in /nix/store/drfy02sf3aqzk6cdrs4lyxa8a6jprl5q-valgrind-3.22.0/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==30886==    by 0x4027F9: initApp (in /nix/store/aakvc5vgnbibxp8rl9b165vmmpxd5ikl-tomato/bin/tomato)
==30886==    by 0x40246F: main (in /nix/store/aakvc5vgnbibxp8rl9b165vmmpxd5ikl-tomato/bin/tomato)
==30886== 
==30886== 31 bytes in 1 blocks are definitely lost in loss record 38 of 119
==30886==    at 0x484276B: malloc (in /nix/store/drfy02sf3aqzk6cdrs4lyxa8a6jprl5q-valgrind-3.22.0/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==30886==    by 0x4027AD: initApp (in /nix/store/aakvc5vgnbibxp8rl9b165vmmpxd5ikl-tomato/bin/tomato)
==30886==    by 0x40246F: main (in /nix/store/aakvc5vgnbibxp8rl9b165vmmpxd5ikl-tomato/bin/tomato)
==30886== 
==30886== 32 bytes in 1 blocks are definitely lost in loss record 41 of 119
==30886==    at 0x484276B: malloc (in /nix/store/drfy02sf3aqzk6cdrs4lyxa8a6jprl5q-valgrind-3.22.0/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==30886==    by 0x40281F: initApp (in /nix/store/aakvc5vgnbibxp8rl9b165vmmpxd5ikl-tomato/bin/tomato)
==30886==    by 0x40246F: main (in /nix/store/aakvc5vgnbibxp8rl9b165vmmpxd5ikl-tomato/bin/tomato)
==30886== 
==30886== 33 bytes in 1 blocks are definitely lost in loss record 42 of 119
==30886==    at 0x484276B: malloc (in /nix/store/drfy02sf3aqzk6cdrs4lyxa8a6jprl5q-valgrind-3.22.0/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==30886==    by 0x40982A: readNotepad (in /nix/store/aakvc5vgnbibxp8rl9b165vmmpxd5ikl-tomato/bin/tomato)
==30886==    by 0x40246F: main (in /nix/store/aakvc5vgnbibxp8rl9b165vmmpxd5ikl-tomato/bin/tomato)
==30886== 
==30886== 160 bytes in 1 blocks are definitely lost in loss record 66 of 119
==30886==    at 0x484276B: malloc (in /nix/store/drfy02sf3aqzk6cdrs4lyxa8a6jprl5q-valgrind-3.22.0/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==30886==    by 0x402748: initApp (in /nix/store/aakvc5vgnbibxp8rl9b165vmmpxd5ikl-tomato/bin/tomato)
==30886==    by 0x40246F: main (in /nix/store/aakvc5vgnbibxp8rl9b165vmmpxd5ikl-tomato/bin/tomato)
==30886== 
==30886== 165 bytes in 5 blocks are definitely lost in loss record 67 of 119
==30886==    at 0x484276B: malloc (in /nix/store/drfy02sf3aqzk6cdrs4lyxa8a6jprl5q-valgrind-3.22.0/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==30886==    by 0x409838: readNotepad (in /nix/store/aakvc5vgnbibxp8rl9b165vmmpxd5ikl-tomato/bin/tomato)
==30886==    by 0x40246F: main (in /nix/store/aakvc5vgnbibxp8rl9b165vmmpxd5ikl-tomato/bin/tomato)
==30886== 
==30886== 168 bytes in 1 blocks are possibly lost in loss record 81 of 119
==30886==    at 0x4849C34: calloc (in /nix/store/drfy02sf3aqzk6cdrs4lyxa8a6jprl5q-valgrind-3.22.0/libexec/valgrind/vgpreload_memcheck-amd64-li
nux.so)
==30886==    by 0x489A79E: tparm_setup (in /nix/store/1ql93amj3rmq5yg7qry7ky6gwpbvdgxp-ncurses-6.4/lib/libncursesw.so.6.4)
==30886==    by 0x489DB10: _nc_tiparm (in /nix/store/1ql93amj3rmq5yg7qry7ky6gwpbvdgxp-ncurses-6.4/lib/libncursesw.so.6.4)
==30886==    by 0x487B8DD: _nc_mvcur_init_sp (in /nix/store/1ql93amj3rmq5yg7qry7ky6gwpbvdgxp-ncurses-6.4/lib/libncursesw.so.6.4)
==30886==    by 0x487C258: newterm_sp (in /nix/store/1ql93amj3rmq5yg7qry7ky6gwpbvdgxp-ncurses-6.4/lib/libncursesw.so.6.4)
==30886==    by 0x487C527: newterm (in /nix/store/1ql93amj3rmq5yg7qry7ky6gwpbvdgxp-ncurses-6.4/lib/libncursesw.so.6.4)
==30886==    by 0x487835F: initscr (in /nix/store/1ql93amj3rmq5yg7qry7ky6gwpbvdgxp-ncurses-6.4/lib/libncursesw.so.6.4)
==30886==    by 0x408F06: initScreen (in /nix/store/aakvc5vgnbibxp8rl9b165vmmpxd5ikl-tomato/bin/tomato)
==30886==    by 0x402467: main (in /nix/store/aakvc5vgnbibxp8rl9b165vmmpxd5ikl-tomato/bin/tomato)
==30886== 
==30886== 168 bytes in 1 blocks are possibly lost in loss record 82 of 119
==30886==    at 0x4849C34: calloc (in /nix/store/drfy02sf3aqzk6cdrs4lyxa8a6jprl5q-valgrind-3.22.0/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==30886==    by 0x489A79E: tparm_setup (in /nix/store/1ql93amj3rmq5yg7qry7ky6gwpbvdgxp-ncurses-6.4/lib/libncursesw.so.6.4)
==30886==    by 0x489DB10: _nc_tiparm (in /nix/store/1ql93amj3rmq5yg7qry7ky6gwpbvdgxp-ncurses-6.4/lib/libncursesw.so.6.4)
==30886==    by 0x487BB86: _nc_mvcur_init_sp (in /nix/store/1ql93amj3rmq5yg7qry7ky6gwpbvdgxp-ncurses-6.4/lib/libncursesw.so.6.4)
==30886==    by 0x487C258: newterm_sp (in /nix/store/1ql93amj3rmq5yg7qry7ky6gwpbvdgxp-ncurses-6.4/lib/libncursesw.so.6.4)
==30886==    by 0x487C527: newterm (in /nix/store/1ql93amj3rmq5yg7qry7ky6gwpbvdgxp-ncurses-6.4/lib/libncursesw.so.6.4)
==30886==    by 0x487835F: initscr (in /nix/store/1ql93amj3rmq5yg7qry7ky6gwpbvdgxp-ncurses-6.4/lib/libncursesw.so.6.4)
==30886==    by 0x408F06: initScreen (in /nix/store/aakvc5vgnbibxp8rl9b165vmmpxd5ikl-tomato/bin/tomato)
==30886==    by 0x402467: main (in /nix/store/aakvc5vgnbibxp8rl9b165vmmpxd5ikl-tomato/bin/tomato)
==30886== 
==30886== LEAK SUMMARY:
==30886==    definitely lost: 498 bytes in 12 blocks
==30886==    indirectly lost: 0 bytes in 0 blocks
==30886==      possibly lost: 402 bytes in 6 blocks
==30886==    still reachable: 468,724 bytes in 462 blocks
==30886==         suppressed: 0 bytes in 0 blocks
==30886== Reachable blocks (those to which a pointer was found) are not shown.
==30886== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==30886== 
==30886== For lists of detected and suppressed errors, rerun with: -s
==30886== ERROR SUMMARY: 17 errors from 16 contexts (suppressed: 0 from 0)
```
### Definitely lost blocks:
```bash
valgrind --track-origins=yes --leak-check=full --show-leak-kinds=definite ./result/bin/tomato
==7709== Memcheck, a memory error detector
==7709== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==7709== Using Valgrind-3.22.0 and LibVEX; rerun with -h for copyright info
==7709== Command: ./result/bin/tomato
==7709== 
Goodbye!
==7709== 
==7709== HEAP SUMMARY:
==7709==     in use at exit: 1,138,656 bytes in 546 blocks
==7709==   total heap usage: 4,662 allocs, 4,116 frees, 2,235,215 bytes allocated
==7709== 
==7709== 20 bytes in 1 blocks are definitely lost in loss record 16 of 118
==7709==    at 0x484276B: malloc (in /nix/store/drfy02sf3aqzk6cdrs4lyxa8a6jprl5q-valgrind-3.22.0/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==7709==    by 0x40278B: initApp (in /nix/store/aakvc5vgnbibxp8rl9b165vmmpxd5ikl-tomato/bin/tomato)
==7709==    by 0x40246F: main (in /nix/store/aakvc5vgnbibxp8rl9b165vmmpxd5ikl-tomato/bin/tomato)
==7709== 
==7709== 28 bytes in 1 blocks are definitely lost in loss record 36 of 118
==7709==    at 0x484276B: malloc (in /nix/store/drfy02sf3aqzk6cdrs4lyxa8a6jprl5q-valgrind-3.22.0/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==7709==    by 0x4027D3: initApp (in /nix/store/aakvc5vgnbibxp8rl9b165vmmpxd5ikl-tomato/bin/tomato)
==7709==    by 0x40246F: main (in /nix/store/aakvc5vgnbibxp8rl9b165vmmpxd5ikl-tomato/bin/tomato)
==7709== 
==7709== 29 bytes in 1 blocks are definitely lost in loss record 37 of 118
==7709==    at 0x484276B: malloc (in /nix/store/drfy02sf3aqzk6cdrs4lyxa8a6jprl5q-valgrind-3.22.0/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==7709==    by 0x4027F9: initApp (in /nix/store/aakvc5vgnbibxp8rl9b165vmmpxd5ikl-tomato/bin/tomato)
==7709==    by 0x40246F: main (in /nix/store/aakvc5vgnbibxp8rl9b165vmmpxd5ikl-tomato/bin/tomato)
==7709== 
==7709== 31 bytes in 1 blocks are definitely lost in loss record 38 of 118
==7709==    at 0x484276B: malloc (in /nix/store/drfy02sf3aqzk6cdrs4lyxa8a6jprl5q-valgrind-3.22.0/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==7709==    by 0x4027AD: initApp (in /nix/store/aakvc5vgnbibxp8rl9b165vmmpxd5ikl-tomato/bin/tomato)
==7709==    by 0x40246F: main (in /nix/store/aakvc5vgnbibxp8rl9b165vmmpxd5ikl-tomato/bin/tomato)
==7709== 
==7709== 32 bytes in 1 blocks are definitely lost in loss record 41 of 118
==7709==    at 0x484276B: malloc (in /nix/store/drfy02sf3aqzk6cdrs4lyxa8a6jprl5q-valgrind-3.22.0/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==7709==    by 0x40281F: initApp (in /nix/store/aakvc5vgnbibxp8rl9b165vmmpxd5ikl-tomato/bin/tomato)
==7709==    by 0x40246F: main (in /nix/store/aakvc5vgnbibxp8rl9b165vmmpxd5ikl-tomato/bin/tomato)
==7709== 
==7709== 160 bytes in 1 blocks are definitely lost in loss record 63 of 118
==7709==    at 0x484276B: malloc (in /nix/store/drfy02sf3aqzk6cdrs4lyxa8a6jprl5q-valgrind-3.22.0/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==7709==    by 0x402748: initApp (in /nix/store/aakvc5vgnbibxp8rl9b165vmmpxd5ikl-tomato/bin/tomato)
==7709==    by 0x40246F: main (in /nix/store/aakvc5vgnbibxp8rl9b165vmmpxd5ikl-tomato/bin/tomato)
==7709== 
==7709== 165 bytes in 5 blocks are definitely lost in loss record 65 of 118
==7709==    at 0x484276B: malloc (in /nix/store/drfy02sf3aqzk6cdrs4lyxa8a6jprl5q-valgrind-3.22.0/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==7709==    by 0x409838: readNotepad (in /nix/store/aakvc5vgnbibxp8rl9b165vmmpxd5ikl-tomato/bin/tomato)
==7709==    by 0x40246F: main (in /nix/store/aakvc5vgnbibxp8rl9b165vmmpxd5ikl-tomato/bin/tomato)
==7709== 
==7709== LEAK SUMMARY:
==7709==    definitely lost: 465 bytes in 11 blocks
==7709==    indirectly lost: 0 bytes in 0 blocks
==7709==      possibly lost: 402 bytes in 6 blocks
==7709==    still reachable: 1,137,789 bytes in 529 blocks
==7709==         suppressed: 0 bytes in 0 blocks
==7709== Reachable blocks (those to which a pointer was found) are not shown.
==7709== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==7709== 
==7709== For lists of detected and suppressed errors, rerun with: -s
==7709== ERROR SUMMARY: 16 errors from 15 contexts (suppressed: 0 from 0)
```
## After:
```bash
valgrind --track-origins=yes --leak-check=full --show-leak-kinds=definite ./result/bin/tomato   
==10956== Memcheck, a memory error detector
==10956== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==10956== Using Valgrind-3.22.0 and LibVEX; rerun with -h for copyright info
==10956== Command: ./result/bin/tomato
==10956== 
Goodbye!
==10956== 
==10956== HEAP SUMMARY:
==10956==     in use at exit: 1,137,736 bytes in 520 blocks
==10956==   total heap usage: 4,592 allocs, 4,072 frees, 2,075,647 bytes allocated
==10956== 
==10956== LEAK SUMMARY:
==10956==    definitely lost: 0 bytes in 0 blocks
==10956==    indirectly lost: 0 bytes in 0 blocks
==10956==      possibly lost: 402 bytes in 6 blocks
==10956==    still reachable: 1,137,334 bytes in 514 blocks
==10956==         suppressed: 0 bytes in 0 blocks
==10956== Reachable blocks (those to which a pointer was found) are not shown.
==10956== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==10956== 
==10956== For lists of detected and suppressed errors, rerun with: -s
==10956== ERROR SUMMARY: 10 errors from 9 contexts (suppressed: 0 from 0)
```

## Conclusion
There is certainly more that can be done, but this is my contribution for now.