### PR TITLE
❄️ renames pkgconfig to pkg-config at nix files

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -7,7 +7,7 @@
 #  `'
 # default.nix
 {
-  pkgconfig,
+  pkg-config,
   libnotify,
   gnumake,
   ncurses,
@@ -40,7 +40,7 @@ stdenv.mkDerivation {
   '';
 
   nativeBuildInputs = [
-    pkgconfig
+    pkg-config
     gnumake
     ncurses
     which
@@ -72,6 +72,6 @@ stdenv.mkDerivation {
     description = "A pomodoro timer written in pure C.";
     homepage = "https://github.com/gabrielzschmitz/Tomato.C";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [luisnquin];
+    maintainers = with maintainers; [luisnquin CarlosCraveiro];
   };
 }

--- a/shell.nix
+++ b/shell.nix
@@ -3,7 +3,7 @@
 with pkgs;
   mkShell {
     buildInputs = [
-      pkgconfig
+      pkg-config
       gnumake
       ncurses
       which


### PR DESCRIPTION
# Problem

The package previously called `pkgconfig` was renamed to `pkg-config` and was thus preventing the Tomato-C flake from being integrated into the nix powered systems.

![Screenshot-2024-04-19_02-12-29](https://github.com/gabrielzschmitz/Tomato.C/assets/85318248/0f98f139-5828-477b-b352-6d580c119bca)

I'm integrating Tomato-C as a overlay in my system, like this:

```nix
# At my flake.nix
# ...
       tomato-c-overlay = final: prev: {
            tomato-c = tomato-c.defaultPackage.${system};
        };

        pkgs = import nixpkgs {
            inherit system;
            config = {
             allowUnfree = true;
             permittedInsecurePackages = [ ];
           };
            overlays = [ tomato-c-overlay ];
        };
# ...
```

# Solution
Simply rename the package from `pkgconfig` to `pkg-config` at nix files.

Additionally, I added myself to the project's flake maintainer list.