### PR TITLE
Fix some small things to increase portability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,11 +53,11 @@ endif
 	mkdir -p ${DESTDIR}${PREFIX}/share/tomato/icons
 	cp -rf sounds ${DESTDIR}${PREFIX}/share/tomato/
 	if [ "${PREFIX}" = "/opt/local" ]; then \
-		sed -i "" "s|Icon=.*|Icon=${DESTDIR}${PREFIX}/share/tomato/icons/tomato.svg|" tomato.desktop; \
+		sed -i "" "s|Icon=.*|Icon=${DESTDIR}${PREFIX}/share/tomato/icons/tomato.svg|" ${DESTDIR}${APPPREFIX}/tomato.desktop; \
 	else \
-		sed -i "s|Icon=.*|Icon=${DESTDIR}${PREFIX}/share/tomato/icons/tomato.svg|" tomato.desktop; \
+		sed -i "s|Icon=.*|Icon=${DESTDIR}${PREFIX}/share/tomato/icons/tomato.svg|" ${DESTDIR}${APPPREFIX}/tomato.desktop; \
 	fi
-	sudo cp -f icons/tomato.svg ${DESTDIR}${PREFIX}/share/tomato/icons
+	cp -f icons/tomato.svg ${DESTDIR}${PREFIX}/share/tomato/icons
 	chmod 755 ${DESTDIR}${PREFIX}/bin/tomato
 ifdef MPVTOGGLE
 	chmod 755 ${DESTDIR}${PREFIX}/bin/tomatonoise

--- a/config.mk
+++ b/config.mk
@@ -21,16 +21,16 @@ endif
 APPPREFIX = $(PREFIX)/share/applications
 LOGPREFIX = .local/share/tomato
 
-# To remove mpv as a dependencie
+# To remove mpv as a dependency
 # comment this line below,
 # and toggle off the sound and noise
 # at config.h
 MPVTOGGLE = 1
 
-DFLAGS = -D_ISOC99_SOURCE -DTOMATONOISE=\"$(PREFIX)/bin/tomatonoise\" -DLOGPREFIX=\"$(LOGPREFIX)\" -DLOGFILE=\"$(LOGPREFIX)/tomato.log\" -DTMPFILE=\"$(LOGPREFIX)/tmp.log\" -DTIMERFILE=\"$(LOGPREFIX)/time.log\" -DNOTEPADFILE=\"$(LOGPREFIX)/notepad.log\"
+DFLAGS = -D_ISOC99_SOURCE -DSOUNDS=\"$(PREFIX)/share/tomato/sounds\" -DTOMATONOISE=\"$(PREFIX)/bin/tomatonoise\" -DLOGPREFIX=\"$(LOGPREFIX)\" -DLOGFILE=\"$(LOGPREFIX)/tomato.log\" -DTMPFILE=\"$(LOGPREFIX)/tmp.log\" -DTIMERFILE=\"$(LOGPREFIX)/time.log\" -DNOTEPADFILE=\"$(LOGPREFIX)/notepad.log\"
 CFLAGS  = -std=c99 -Wall -Wextra -pedantic -Wunused-result -Wno-unused-variable -Os ${DFLAGS}
 
-ifeq ($(OS),Darwin)
+ifeq ($(OS),$(filter $(OS),Darwin OpenBSD))
     ifdef MPVTOGGLE
         LDLIBS  = -lncurses -lmpv
     else

--- a/notify.c
+++ b/notify.c
@@ -30,7 +30,7 @@ void notify(const char *message) {
     else
       send_notification("A pomodoro has ended!", "Unpause to start the pause");
 
-    play_audio("/usr/local/share/tomato/sounds/dfltnotify.mp3");
+    play_audio("dfltnotify.mp3");
   }
   /* Autostart pause notification */
   else if (strcmp(message, "autostartpause") == 0) {
@@ -41,7 +41,7 @@ void notify(const char *message) {
     else
       send_notification("A pause has ended!", "Unpause to continue");
 
-    play_audio("/usr/local/share/tomato/sounds/pausenotify.mp3");
+    play_audio("pausenotify.mp3");
   }
   /* Work notification */
   else if (strcmp(message, "worktime") == 0) {
@@ -52,7 +52,7 @@ void notify(const char *message) {
     else
       send_notification("Work!", "You need to focus!");
 
-    play_audio("/usr/local/share/tomato/sounds/dfltnotify.mp3");
+    play_audio("dfltnotify.mp3");
   }
   /* Short Pause notification */
   else if (strcmp(message, "shortpause") == 0) {
@@ -63,7 +63,7 @@ void notify(const char *message) {
     else
       send_notification("Pause Break", "You have some time to chill");
 
-    play_audio("/usr/local/share/tomato/sounds/pausenotify.mp3");
+    play_audio("pausenotify.mp3");
   }
   /* Long Pause notification */
   else if (strcmp(message, "longpause") == 0) {
@@ -74,7 +74,7 @@ void notify(const char *message) {
     else
       send_notification("Long Pause Break", "You have some time to chill");
 
-    play_audio("/usr/local/share/tomato/sounds/pausenotify.mp3");
+    play_audio("pausenotify.mp3");
   }
   /* End of cycle notification */
   else {
@@ -87,7 +87,7 @@ void notify(const char *message) {
     else
       send_notification("End of Pomodoro Cycle", "Feel free to start another!");
 
-    play_audio("/usr/local/share/tomato/sounds/endnotify.mp3");
+    play_audio("endnotify.mp3");
   }
 }
 
@@ -110,15 +110,15 @@ void send_notification(char *title, char *description) {
   (void)system((char *)command);
 }
 
-void play_audio(char *record_path) {
+void play_audio(char *sound_file) {
   if (SOUND == 1 && WSL == 0) {
     int max_audio_cmd_length = 256;
 
     char *command[max_audio_cmd_length];
 
     snprintf((char *)command, max_audio_cmd_length,
-             "mpv --no-vid --no-input-terminal --volume=50 %s --really-quiet &",
-             record_path);
+             "mpv --no-vid --no-input-terminal --volume=50 %s/%s --really-quiet &",
+             SOUNDS, sound_file);
     (void)system((char *)command);
   }
 }

--- a/tomatonoise.c
+++ b/tomatonoise.c
@@ -20,6 +20,9 @@ int play(char *file, char *volume, char *title) {
     return 1;
   }
 
+  char path[512];
+  snprintf(path, 512, "%s/%s", SOUNDS, file);
+
   /* Set loop */
   char loop[4] = "inf";
   char quit[2] = "1";
@@ -52,8 +55,8 @@ int play(char *file, char *volume, char *title) {
   // Done setting up options.
   mpvCheckError(mpv_initialize(mpvCtx));
 
-  // Play this file.
-  const char *load[] = {"loadfile", file, NULL};
+  // Play this path.
+  const char *load[] = {"loadfile", path, NULL};
   mpvCheckError(mpv_command(mpvCtx, load));
   const char *volumecmd[] = {"set", "volume", volume, NULL};
   mpvCheckError(mpv_command(mpvCtx, volumecmd));
@@ -101,7 +104,7 @@ int play(char *file, char *volume, char *title) {
 int main(int argc, char *argv[]) {
   if (argc == 0) return 1;
 
-  play(argv[0], argv[1], argv[2]);
+  play(argv[1], argv[2], argv[3]);
 
   return 0;
 }

--- a/util.c
+++ b/util.c
@@ -251,11 +251,8 @@ void setLogVars(appData *app) {
   char lastline[1024] = {
     0,
   };
-  int lastlineIndex = 0;
-  /* Just to get the last line and count lines */
-  while (fgets(lastline, 1024, log) != NULL) {
-    lastlineIndex++;
-  }
+  /* Just to get the last line */
+  while (fgets(lastline, 1024, log) != NULL) {}
 
   /* Get variables */
   if (sscanf(lastline, "%d/%d WT %d D %d %d %d", &app->pomodoroCounter,
@@ -516,7 +513,8 @@ void toggleNoise(appData *app, int noise) {
       app->playRainNoise = 1;
       if (app->runRainOnce == 0) {
         char *rainnoisecmd[] = {
-          "/usr/local/share/tomato/sounds/ambience-rain.wav", app->rainVolume,
+          "tomatonoise",
+          "ambience-rain.wav", app->rainVolume,
           "tomato noise rain", NULL};
         app->rainNoisePID = fork();
         app->runRainOnce = 1;
@@ -539,7 +537,8 @@ void toggleNoise(appData *app, int noise) {
       app->playFireNoise = 1;
       if (app->runFireOnce == 0) {
         char *firenoisecmd[] = {
-          "/usr/local/share/tomato/sounds/ambience-fire.wav", app->fireVolume,
+          "tomatonoise",
+          "ambience-fire.wav", app->fireVolume,
           "tomato noise fire", NULL};
         app->fireNoisePID = fork();
         app->runFireOnce = 1;
@@ -562,7 +561,8 @@ void toggleNoise(appData *app, int noise) {
       app->playWindNoise = 1;
       if (app->runWindOnce == 0) {
         char *windnoisecmd[] = {
-          "/usr/local/share/tomato/sounds/ambience-wind.wav", app->windVolume,
+          "tomatonoise",
+          "ambience-wind.wav", app->windVolume,
           "tomato noise wind", NULL};
         app->windNoisePID = fork();
         app->runWindOnce = 1;
@@ -585,7 +585,8 @@ void toggleNoise(appData *app, int noise) {
       app->playThunderNoise = 1;
       if (app->runThunderOnce == 0) {
         char *thundernoisecmd[] = {
-          "/usr/local/share/tomato/sounds/ambience-thunder.wav",
+          "tomatonoise",
+          "ambience-thunder.wav",
           app->thunderVolume, "tomato noise thunder", NULL};
         app->thunderNoisePID = fork();
         app->runThunderOnce = 1;
@@ -630,14 +631,14 @@ void controlVolumeNoise(appData *app, int noise, char sign) {
   if (noise == 1) {
     if (sign == '-') {
       uintmax_t rainVolume = strtoumax(app->rainVolume, NULL, 10);
-      if (rainVolume > 0) sprintf(app->rainVolume, "%lu", (rainVolume - 10));
+      if (rainVolume > 0) sprintf(app->rainVolume, "%llu", (rainVolume - 10));
       FILE *tmpfile;
       tmpfile = fopen("/tmp/tomato_rain_state", "w");
       fprintf(tmpfile, "%s ON", app->rainVolume);
       fclose(tmpfile);
     } else if (sign == '+') {
       uintmax_t rainVolume = strtoumax(app->rainVolume, NULL, 10);
-      if (rainVolume < 100) sprintf(app->rainVolume, "%lu", (rainVolume + 10));
+      if (rainVolume < 100) sprintf(app->rainVolume, "%llu", (rainVolume + 10));
       FILE *tmpfile;
       tmpfile = fopen("/tmp/tomato_rain_state", "w");
       fprintf(tmpfile, "%s ON", app->rainVolume);
@@ -646,14 +647,14 @@ void controlVolumeNoise(appData *app, int noise, char sign) {
   } else if (noise == 2) {
     if (sign == '-') {
       uintmax_t fireVolume = strtoumax(app->fireVolume, NULL, 10);
-      if (fireVolume > 0) sprintf(app->fireVolume, "%lu", (fireVolume - 10));
+      if (fireVolume > 0) sprintf(app->fireVolume, "%llu", (fireVolume - 10));
       FILE *tmpfile;
       tmpfile = fopen("/tmp/tomato_fire_state", "w");
       fprintf(tmpfile, "%s ON", app->fireVolume);
       fclose(tmpfile);
     } else if (sign == '+') {
       uintmax_t fireVolume = strtoumax(app->fireVolume, NULL, 10);
-      if (fireVolume < 100) sprintf(app->fireVolume, "%lu", (fireVolume + 10));
+      if (fireVolume < 100) sprintf(app->fireVolume, "%llu", (fireVolume + 10));
       FILE *tmpfile;
       tmpfile = fopen("/tmp/tomato_fire_state", "w");
       fprintf(tmpfile, "%s ON", app->fireVolume);
@@ -662,14 +663,14 @@ void controlVolumeNoise(appData *app, int noise, char sign) {
   } else if (noise == 3) {
     if (sign == '-') {
       uintmax_t windVolume = strtoumax(app->windVolume, NULL, 10);
-      if (windVolume > 0) sprintf(app->windVolume, "%lu", (windVolume - 10));
+      if (windVolume > 0) sprintf(app->windVolume, "%llu", (windVolume - 10));
       FILE *tmpfile;
       tmpfile = fopen("/tmp/tomato_wind_state", "w");
       fprintf(tmpfile, "%s ON", app->windVolume);
       fclose(tmpfile);
     } else if (sign == '+') {
       uintmax_t windVolume = strtoumax(app->windVolume, NULL, 10);
-      if (windVolume < 100) sprintf(app->windVolume, "%lu", (windVolume + 10));
+      if (windVolume < 100) sprintf(app->windVolume, "%llu", (windVolume + 10));
       FILE *tmpfile;
       tmpfile = fopen("/tmp/tomato_wind_state", "w");
       fprintf(tmpfile, "%s ON", app->windVolume);
@@ -679,7 +680,7 @@ void controlVolumeNoise(appData *app, int noise, char sign) {
     if (sign == '-') {
       uintmax_t thunderVolume = strtoumax(app->thunderVolume, NULL, 10);
       if (thunderVolume > 0)
-        sprintf(app->thunderVolume, "%lu", (thunderVolume - 10));
+        sprintf(app->thunderVolume, "%llu", (thunderVolume - 10));
       FILE *tmpfile;
       tmpfile = fopen("/tmp/tomato_thunder_state", "w");
       fprintf(tmpfile, "%s ON", app->thunderVolume);
@@ -687,7 +688,7 @@ void controlVolumeNoise(appData *app, int noise, char sign) {
     } else if (sign == '+') {
       uintmax_t thunderVolume = strtoumax(app->thunderVolume, NULL, 10);
       if (thunderVolume < 100)
-        sprintf(app->thunderVolume, "%lu", (thunderVolume + 10));
+        sprintf(app->thunderVolume, "%llu", (thunderVolume + 10));
       FILE *tmpfile;
       tmpfile = fopen("/tmp/tomato_thunder_state", "w");
       fprintf(tmpfile, "%s ON", app->thunderVolume);


### PR DESCRIPTION
A few small fixes as I was trying to get it working on OpenBSD:

- remove unnecessary `sudo` in make install (make install should be run as superuser already, and sudo isn't present on some systems)
- remove hardcoding of sounds directory, base it on $PREFIX like other things are
- make tomatonoise use argv [1] to [3] for arguments, have argv[0] be the name of the program, as is standard (to demonstrate: you may see that before this fix you cannot run tomatonoise from a shell to test it, because the shell sets argv[0] to the path of the program and [1] onwards as arguments)
- fix a few warnings and stuff