### PR TITLE
fix mpv invocation

### DIFF
--- a/notify.c
+++ b/notify.c
@@ -117,7 +117,7 @@ void play_audio(char *sound_file) {
     char *command[max_audio_cmd_length];
 
     snprintf((char *)command, max_audio_cmd_length,
-             "mpv --no-vid --no-input-terminal --volume=50 %s/%s --really-quiet &",
+             "mpv --loop=no --keep-open=no --no-vid --no-input-terminal --volume=50 %s/%s --really-quiet &",
              SOUNDS, sound_file);
     (void)system((char *)command);
   }


### PR DESCRIPTION
first problem:
if you have mpv config, and it includes `loop=inf` (or `loop-file=inf`), then when you start timer, the notification sound will just repeat and never end (until you manually kill mpv process)
solution: add `--loop=no` argument to mpv command

and then there is another problem:
if your mpv config includes `keep-open=yes`, then after the sound, mpv process just dont exit (until you manually kill mpv process)
solution: add `--keep-open=no` argument to mpv command

cli parameters take precedence over config
